### PR TITLE
Corrected typo in 12-day.md

### DIFF
--- a/docs/12-day.md
+++ b/docs/12-day.md
@@ -333,7 +333,7 @@ We can specify the length of the substring we look for in a text, using a curly 
 
 ```js
 const txt = 'This regular expression example was made in December 6,  2019.'
-const pattern = /\\b\w{4}\b/g  //  exactly four character words
+const pattern = /\b\w{4}\b/g  //  exactly four character words
 const matches = txt.match(pattern)
 console.log(matches)  //['This', 'made', '2019']
 ```


### PR DESCRIPTION
There was a typo in the Quantifier section,
"const pattern = /\\b\w{4}\b/g  //  exactly four character words" In the above line there was an extra back slash before the first \\b.